### PR TITLE
Fix selected answer carrying over to next question

### DIFF
--- a/py_quiz/__main__.py
+++ b/py_quiz/__main__.py
@@ -83,13 +83,17 @@ class Application(tk.Frame):
 	Function to validate the selected answer with the correct answer. If they match, increase the score by 5.
 	'''
         print "In Validate answer:"
-        print "selected:",self.selected_answer
+        if not self.selected_answer:
+            print "No answer selected"
+        else:
+            print "selected:", self.selected_answer
+
         print "Correct:",self.correct_answer
         self.py_var = ["PY_VAR1","PY_VAR2","PY_VAR3","PY_VAR4"]
         if str(self.selected_answer) == str(self.correct_answer):
             self.score.set(int(self.score.get()) + 5)
             print "Correct!"
-        elif str(self.selected_answer) in self.py_var :
+        elif str(self.selected_answer) in self.py_var:
             print "IN py var if"
             pass
         else:
@@ -112,7 +116,9 @@ class Application(tk.Frame):
             randomindex = random.randint(0,len(self.questions["results"])-1)
             self.question_index.append(randomindex)
             print "Debug:"
-            print self.questions["results"][randomindex]["question"] 
+            print self.questions["results"][randomindex]["question"]
+
+        self.selected_answer = ""  # reset selected answer
         self.correct_answer = self.questions["results"][randomindex]["correct_answer"] # parse the correct answer from JSON file and store it.
         #print self.correct_answer
         self.answers = self.questions["results"][randomindex]["incorrect_answers"] # parse the other incorrect answers


### PR DESCRIPTION
Fixed issue:
When you wouldn't select an answer, the console would print out the previous selected answer form the question before. 

This PR fixes the issue by resetting the selected answer on every turn and adding a custom print out if no answer is selected.